### PR TITLE
BUGFIX Recursion tab not hidden if “recursion” config is false

### DIFF
--- a/src/Page/EventPage.php
+++ b/src/Page/EventPage.php
@@ -290,7 +290,7 @@ class EventPage extends \Page
         }
 
         if (!$this->config()->get('recursion')) {
-            $fields->removeByName('RecurringEvents');
+            $fields->removeByName('ChildPages');
         }
 
         return $fields;


### PR DESCRIPTION
resolves #8