### PR TITLE
feat: show all events by default when no date filters applied

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -230,8 +230,8 @@ class CalendarController extends \PageController
         return [
             'Calendar' => $this->calendar,
             'Events' => $paginatedEvents,
-            'CurrentFromDate' => $fromDate->format('Y-m-d'),
-            'CurrentToDate' => $toDate->format('Y-m-d'),
+            'CurrentFromDate' => $fromDate ? $fromDate->format('Y-m-d') : null,
+            'CurrentToDate' => $toDate ? $toDate->format('Y-m-d') : null,
             'RecurringEventsCount' => $this->getRecurringEventsCount(),
             'OneTimeEventsCount' => $this->getOneTimeEventsCount(),
             'AvailableCategories' => $this->getAvailableCategoriesForTemplate($request),
@@ -240,12 +240,12 @@ class CalendarController extends \PageController
     }
 
     /**
-     * Get from date from request or default
+     * Get from date from request or null if no filter applied
      *
      * @param HTTPRequest $request
-     * @return Carbon
+     * @return Carbon|null
      */
-    protected function getFromDate(HTTPRequest $request): Carbon
+    protected function getFromDate(HTTPRequest $request): ?Carbon
     {
         $from = $request->getVar('from');
 
@@ -253,17 +253,17 @@ class CalendarController extends \PageController
             return Carbon::createFromFormat('Y-m-d', $from);
         }
 
-        // Default to start of current month
-        return Carbon::now()->startOfMonth();
+        // Return null when no date filter is applied - this will show all events
+        return null;
     }
 
     /**
-     * Get to date from request or default
+     * Get to date from request or null if no filter applied
      *
      * @param HTTPRequest $request
-     * @return Carbon
+     * @return Carbon|null
      */
-    protected function getToDate(HTTPRequest $request): Carbon
+    protected function getToDate(HTTPRequest $request): ?Carbon
     {
         $to = $request->getVar('to');
 
@@ -271,8 +271,8 @@ class CalendarController extends \PageController
             return Carbon::createFromFormat('Y-m-d', $to);
         }
 
-        // Default to end of next month
-        return Carbon::now()->addMonth()->endOfMonth();
+        // Return null when no date filter is applied - this will show all events
+        return null;
     }
 
     /**

--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -47,7 +47,22 @@ class Calendar extends \Page
     private static string $icon_class = 'font-icon-p-event-alt';
 
     /**
-     * Default window in years for recurring events when no date filter is applied
+     * Default window in years for recurring events when no date filter is applied.
+     *
+     * Rationale:
+     * The default value of 2 years was chosen to provide a reasonable balance between
+     * displaying a comprehensive set of upcoming recurring events and maintaining
+     * acceptable performance. Loading all possible recurrences for events with no
+     * date filter can be expensive, especially for events with complex recurrence rules.
+     *
+     * Performance Impact:
+     * Increasing this window will result in more recurring event instances being
+     * generated and loaded, which can significantly impact page load times and
+     * server resource usage. Conversely, reducing the window may cause some future
+     * recurring events to be omitted from the display.
+     *
+     * Adjust this value based on the expected number of recurring events and the
+     * performance characteristics of your hosting environment.
      *
      * @var int
      */
@@ -307,9 +322,9 @@ class Calendar extends \Page
         foreach ($recurringEvents as $event) {
             // For recurring events, we need date ranges for occurrence generation
             // If no dates provided, use configurable default range for recurring events
-            $windowYears = $this->config()->get('default_recurring_window_years') ?: 2;
+            $windowYears = $this->config()->get('default_recurring_window_years') ?: self::$default_recurring_window_years;
             $occurrenceFromDate = $fromDate ?: Carbon::now()->startOfYear();
-            $occurrenceToDate = $toDate ?: Carbon::now()->copy()->addYears($windowYears - 1)->endOfYear();
+            $occurrenceToDate = $toDate ?: Carbon::now()->copy()->addYears($windowYears)->endOfYear();
 
             // Get occurrences within the date range using Carbon recursion
             $occurrences = $event->getOccurrences($occurrenceFromDate, $occurrenceToDate);

--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -47,6 +47,13 @@ class Calendar extends \Page
     private static string $icon_class = 'font-icon-p-event-alt';
 
     /**
+     * Default window in years for recurring events when no date filter is applied
+     *
+     * @var int
+     */
+    private static int $default_recurring_window_years = 2;
+
+    /**
      * @var array
      */
     private static array $casting = [
@@ -299,9 +306,10 @@ class Calendar extends \Page
 
         foreach ($recurringEvents as $event) {
             // For recurring events, we need date ranges for occurrence generation
-            // If no dates provided, use a reasonable default range for recurring events
+            // If no dates provided, use configurable default range for recurring events
+            $windowYears = $this->config()->get('default_recurring_window_years') ?: 2;
             $occurrenceFromDate = $fromDate ?: Carbon::now()->startOfYear();
-            $occurrenceToDate = $toDate ?: Carbon::now()->addYear()->endOfYear();
+            $occurrenceToDate = $toDate ?: Carbon::now()->copy()->addYears($windowYears - 1)->endOfYear();
 
             // Get occurrences within the date range using Carbon recursion
             $occurrences = $event->getOccurrences($occurrenceFromDate, $occurrenceToDate);

--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -319,10 +319,12 @@ class Calendar extends \Page
             ])
             ->exclude('Recursion', 'NONE');
 
+        // Retrieve the recurring window years config value once before the loop for performance
+        $windowYears = $this->config()->get('default_recurring_window_years') ?? self::$default_recurring_window_years;
+
         foreach ($recurringEvents as $event) {
             // For recurring events, we need date ranges for occurrence generation
             // If no dates provided, use configurable default range for recurring events
-            $windowYears = $this->config()->get('default_recurring_window_years') ?: self::$default_recurring_window_years;
             $occurrenceFromDate = $fromDate ?: Carbon::now()->startOfYear();
             $occurrenceToDate = $toDate ?: Carbon::now()->copy()->addYears($windowYears)->endOfYear();
 

--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -320,7 +320,8 @@ class Calendar extends \Page
             ->exclude('Recursion', 'NONE');
 
         // Retrieve the recurring window years config value once before the loop for performance
-        $windowYears = $this->config()->get('default_recurring_window_years') ?? self::config()->get('default_recurring_window_years');
+        $windowYears = $this->config()->get('default_recurring_window_years')
+            ?? self::config()->get('default_recurring_window_years');
 
         foreach ($recurringEvents as $event) {
             // For recurring events, we need date ranges for occurrence generation

--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -257,22 +257,34 @@ class Calendar extends \Page
      */
     public function getEventsFeed(?int $limit = null, $categories = null, $fromDate = null, $toDate = null): ArrayList
     {
-        // Parse dates
-        $fromDate = $fromDate ? Carbon::parse($fromDate) : Carbon::now();
-        $toDate = $toDate ? Carbon::parse($toDate) : Carbon::now()->addMonths(6);
+        // Parse dates - only apply date filtering if dates are explicitly provided
+        $applyDateFilter = ($fromDate !== null || $toDate !== null);
+        $fromDate = $fromDate ? Carbon::parse($fromDate) : null;
+        $toDate = $toDate ? Carbon::parse($toDate) : null;
 
         $allEvents = ArrayList::create();
 
         // Get regular (non-recurring) events
-        $regularEvents = EventPage::get()
-            ->filter([
-                'ParentID' => $this->ID,
-                'Recursion' => 'NONE',
-            ])
-            ->where([
-                'StartDate >= ?' => $fromDate->format('Y-m-d'),
-                'StartDate <= ?' => $toDate->format('Y-m-d'),
-            ]);
+        $regularEventsFilter = [
+            'ParentID' => $this->ID,
+            'Recursion' => 'NONE',
+        ];
+
+        $regularEvents = EventPage::get()->filter($regularEventsFilter);
+
+        // Only apply date filtering if dates were explicitly provided
+        if ($applyDateFilter) {
+            $whereClause = [];
+            if ($fromDate) {
+                $whereClause['StartDate >= ?'] = $fromDate->format('Y-m-d');
+            }
+            if ($toDate) {
+                $whereClause['StartDate <= ?'] = $toDate->format('Y-m-d');
+            }
+            if (!empty($whereClause)) {
+                $regularEvents = $regularEvents->where($whereClause);
+            }
+        }
 
         foreach ($regularEvents as $event) {
             $allEvents->push($event);
@@ -286,8 +298,13 @@ class Calendar extends \Page
             ->exclude('Recursion', 'NONE');
 
         foreach ($recurringEvents as $event) {
+            // For recurring events, we need date ranges for occurrence generation
+            // If no dates provided, use a reasonable default range for recurring events
+            $occurrenceFromDate = $fromDate ?: Carbon::now()->startOfYear();
+            $occurrenceToDate = $toDate ?: Carbon::now()->addYear()->endOfYear();
+
             // Get occurrences within the date range using Carbon recursion
-            $occurrences = $event->getOccurrences($fromDate, $toDate);
+            $occurrences = $event->getOccurrences($occurrenceFromDate, $occurrenceToDate);
 
             // Get event exceptions for this event
             $exceptions = $event->EventExceptions();

--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -320,7 +320,7 @@ class Calendar extends \Page
             ->exclude('Recursion', 'NONE');
 
         // Retrieve the recurring window years config value once before the loop for performance
-        $windowYears = $this->config()->get('default_recurring_window_years') ?? self::$default_recurring_window_years;
+        $windowYears = $this->config()->get('default_recurring_window_years') ?? self::config()->get('default_recurring_window_years');
 
         foreach ($recurringEvents as $event) {
             // For recurring events, we need date ranges for occurrence generation


### PR DESCRIPTION
## Summary

This PR modifies the calendar system to show all events by default when no date filters are applied, rather than limiting to a narrow date range.

## Problem

Previously, the calendar would only show events within a default date range (current month to next month), which meant events outside this range were not visible in the default calendar view. This caused issues where events scheduled for future months would not appear unless specific date filters were applied.

## Solution

### Changes Made

1. **CalendarController Methods** (`src/Controller/CalendarController.php`):
   - Modified `getFromDate()` and `getToDate()` to return `null` when no date parameters are provided
   - Changed return types to `?Carbon` to allow null values
   - Updated template data handling to support null dates

2. **Calendar Feed Logic** (`src/Page/Calendar.php`):
   - Updated `getEventsFeed()` to detect when date filtering should be applied
   - When no dates provided, skips date filtering entirely to show all events
   - For recurring events, uses a reasonable 2-year window when no dates specified
   - Maintains existing date filtering when dates are explicitly provided

### Behavior Changes

- **Before**: Calendar showed only events within current month + 1 month by default
- **After**: Calendar shows all events by default
- **Date Filtering**: Still works when `from` and `to` parameters are provided via URL

## Testing

✅ **Default View**: Shows all events without date restrictions  
✅ **Date Filtering**: Explicit date parameters still filter correctly  
✅ **Backward Compatibility**: Existing functionality preserved  
✅ **Events Feed**: JSON API works correctly for both scenarios  

## Example

```bash
# Shows all events
GET /calendar-of-events/events

# Shows only September events  
GET /calendar-of-events/events?from=2025-09-01&to=2025-09-30
```

This resolves issues where events scheduled for future months were not appearing in default calendar views.