### PR TITLE
Fix: Respect RecursionEndDate as hard limit for recurring events

### DIFF
--- a/src/Traits/CarbonRecursion.php
+++ b/src/Traits/CarbonRecursion.php
@@ -135,9 +135,13 @@ trait CarbonRecursion
         $rangeStart = $startDate ? Carbon::parse($startDate) : $eventStart;
         $rangeEnd = $endDate ? Carbon::parse($endDate) : null;
 
-        // Use recursion end date if no range end specified
-        if (!$rangeEnd && $this->RecursionEndDate) {
-            $rangeEnd = Carbon::parse($this->RecursionEndDate);
+        // ALWAYS respect RecursionEndDate as a hard limit
+        // Use the EARLIER of the query end date or the recursion end date
+        if ($this->RecursionEndDate) {
+            $recursionEnd = Carbon::parse($this->RecursionEndDate);
+            if (!$rangeEnd || $recursionEnd->lt($rangeEnd)) {
+                $rangeEnd = $recursionEnd;
+            }
         }
 
         // Default to 2 years if no end date

--- a/tests/CarbonRecursionTest.php
+++ b/tests/CarbonRecursionTest.php
@@ -330,4 +330,116 @@ class CarbonRecursionTest extends SapphireTest
         $occurrences = iterator_to_array($event->getOccurrences('2025-06-21', '2025-06-25'));
         $this->assertCount(0, $occurrences);
     }
+
+    /**
+     * Test that RecursionEndDate is respected even when querying larger date ranges
+     *
+     * This tests the bug fix where RecursionEndDate was being ignored when
+     * date ranges were passed to getOccurrences()
+     */
+    public function testRecursionEndDateRespected()
+    {
+        $event = EventPage::create([
+            'Title' => 'Daily Reminder',
+            'StartDate' => '2025-06-01',
+            'StartTime' => '08:00:00',
+            'Recursion' => 'DAILY',
+            'Interval' => 1,
+            'RecursionEndDate' => '2025-06-10', // Event should stop on June 10
+            'ParentID' => $this->parentPage->ID,
+        ]);
+
+        $event->write();
+
+        // Query for a much larger range (entire month)
+        // Even though we're querying until June 30, the event should stop at RecursionEndDate
+        $occurrences = iterator_to_array($event->getOccurrences('2025-06-01', '2025-06-30'));
+
+        // Should only have occurrences from June 1-10 (10 days)
+        $this->assertCount(10, $occurrences, 'Event should only generate 10 occurrences despite larger query range');
+
+        // Check that all occurrences are within the RecursionEndDate
+        foreach ($occurrences as $occurrence) {
+            $occurrenceDate = Carbon::parse($occurrence->StartDate);
+            $endDate = Carbon::parse('2025-06-10');
+            $this->assertLessThanOrEqual(
+                $endDate,
+                $occurrenceDate,
+                "Occurrence {$occurrence->StartDate} should not be after RecursionEndDate 2025-06-10"
+            );
+        }
+
+        // Verify the last occurrence is on the RecursionEndDate
+        $lastOccurrence = end($occurrences);
+        $this->assertEquals('2025-06-10', $lastOccurrence->StartDate, 'Last occurrence should be on RecursionEndDate');
+
+        // Verify no occurrences exist after the RecursionEndDate
+        $dates = array_map(function ($occ) {
+            return $occ->StartDate;
+        }, $occurrences);
+        $this->assertNotContains('2025-06-11', $dates, 'Should not have occurrence after RecursionEndDate');
+        $this->assertNotContains('2025-06-15', $dates, 'Should not have occurrence after RecursionEndDate');
+    }
+
+    /**
+     * Test that RecursionEndDate works correctly with weekly events
+     */
+    public function testRecursionEndDateWithWeeklyEvents()
+    {
+        $event = EventPage::create([
+            'Title' => 'Weekly Class',
+            'StartDate' => '2025-06-02', // Monday
+            'StartTime' => '10:00:00',
+            'Recursion' => 'WEEKLY',
+            'Interval' => 1,
+            'RecursionEndDate' => '2025-06-16', // Should include Jun 2, 9, 16 but not 23
+            'ParentID' => $this->parentPage->ID,
+        ]);
+
+        $event->write();
+
+        // Query for 2 months even though event ends much sooner
+        $occurrences = iterator_to_array($event->getOccurrences('2025-06-01', '2025-07-31'));
+
+        // Should have exactly 3 weekly occurrences
+        $this->assertCount(3, $occurrences, 'Weekly event should generate exactly 3 occurrences');
+
+        $dates = array_map(function ($occ) {
+            return $occ->StartDate;
+        }, $occurrences);
+        $expectedDates = ['2025-06-02', '2025-06-09', '2025-06-16'];
+
+        $this->assertEquals($expectedDates, $dates, 'Should only have occurrences up to RecursionEndDate');
+        $this->assertNotContains('2025-06-23', $dates, 'Should not include occurrence after RecursionEndDate');
+    }
+
+    /**
+     * Test that RecursionEndDate works when it falls between recurring intervals
+     */
+    public function testRecursionEndDateBetweenIntervals()
+    {
+        $event = EventPage::create([
+            'Title' => 'Every 3 Days',
+            'StartDate' => '2025-06-01',
+            'Recursion' => 'DAILY',
+            'Interval' => 3, // Every 3 days: 1st, 4th, 7th, 10th, 13th...
+            'RecursionEndDate' => '2025-06-08', // Ends between 7th and 10th
+            'ParentID' => $this->parentPage->ID,
+        ]);
+
+        $event->write();
+
+        $occurrences = iterator_to_array($event->getOccurrences('2025-06-01', '2025-06-30'));
+
+        // Should have occurrences on: Jun 1, 4, 7 (but not 10 since it's after end date)
+        $this->assertCount(3, $occurrences);
+
+        $dates = array_map(function ($occ) {
+            return $occ->StartDate;
+        }, $occurrences);
+        $expectedDates = ['2025-06-01', '2025-06-04', '2025-06-07'];
+
+        $this->assertEquals($expectedDates, $dates);
+        $this->assertNotContains('2025-06-10', $dates, 'Should not include Jun 10 as it exceeds RecursionEndDate');
+    }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where the `RecursionEndDate` field was being ignored when date ranges were passed to `getOccurrences()`, causing recurring events to continue generating instances past their specified end date.

## Problem
When querying for event occurrences with an explicit date range (e.g., from Calendar controller or frontend calendar views), the `RecursionEndDate` was being overridden by the query's end date parameter. This meant recurring events would continue to generate instances beyond their configured end date if the query range was larger.

## Solution
Changed the logic in `CarbonRecursion::createCarbonPeriod()` to **always respect `RecursionEndDate` as a hard limit**, using whichever date is earlier: the query end date or the `RecursionEndDate`.

### Code Changes
- Modified `src/Traits/CarbonRecursion.php` lines 119-133
- Instead of only using `RecursionEndDate` when no range end is specified, now it's always checked
- Uses `Carbon::lt()` comparison to pick the earlier of the two dates

## Testing
Added three comprehensive test cases in `tests/CarbonRecursionTest.php`:

1. **`testRecursionEndDateRespected`** - Verifies daily recurring events stop at `RecursionEndDate` even when querying much larger date ranges
2. **`testRecursionEndDateWithWeeklyEvents`** - Tests that weekly recurring events respect the end date limit
3. **`testRecursionEndDateBetweenIntervals`** - Ensures events stop correctly even when the end date falls between recurring intervals

**Test Results:**
```
OK (12 tests, 78 assertions)
```

All existing tests continue to pass, validating backward compatibility.

## Impact
- ✅ Recurring events now correctly stop at or before `RecursionEndDate`
- ✅ No breaking changes to existing functionality
- ✅ Backward compatible with all existing events
- ✅ Improves data integrity and user expectations