### PR TITLE
Fix PHPCS trailing whitespace violations

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -555,7 +555,7 @@ class CalendarController extends \PageController
             } else {
                 // Timed event - parse in the configured timezone, then convert to UTC
                 $timezone = $this->config()->get('timezone');
-                
+
                 $startDateTime = Carbon::parse($event->StartDate . ' ' . $event->StartTime, $timezone);
                 $ics[] = 'DTSTART:' . $startDateTime->utc()->format('Ymd\THis\Z');
 

--- a/src/Page/EventPage.php
+++ b/src/Page/EventPage.php
@@ -278,7 +278,7 @@ class EventPage extends \Page
 
     /**
      * Get the state of this event for GridField display
-     * 
+     *
      * @return string
      */
     public function getEventState(): string
@@ -286,7 +286,7 @@ class EventPage extends \Page
         $today = Carbon::now()->format('Y-m-d');
         $startDate = $this->StartDate;
         $isRecurring = $this->eventRecurs();
-        
+
         if ($startDate === $today) {
             return $isRecurring ? 'Recurring (Today)' : 'Today';
         } elseif ($startDate > $today) {


### PR DESCRIPTION
## Overview

Fixes PHPCS trailing whitespace violations that were causing CI failures.

## Problem

GitHub Actions CI workflow was failing on the `phplinting` job due to trailing whitespace violations introduced in recent commits.

## Changes

Removed trailing whitespace from 3 lines:
- `CalendarController.php:558` - 1 violation
- `EventPage.php:281` - 1 violation  
- `EventPage.php:289` - 1 violation

## Fix Method

Used `phpcbf` (PHP Code Beautifier and Fixer) to automatically fix violations:
```bash
vendor/bin/phpcbf vendor/dynamic/silverstripe-calendar/src
```

## Verification

All PHPCS checks now pass:
```
32 / 32 (100%)
Time: 208ms; Memory: 8MB
✅ No errors, no warnings
```

## Impact

- ✅ Resolves CI workflow failures
- ✅ Ensures code meets SilverStripe coding standards
- ✅ No functional changes - whitespace only

This should allow the CI workflow to pass successfully.