### PR TITLE
Fix EventException time field auto-fill causing unintended overrides

### DIFF
--- a/src/Model/EventException.php
+++ b/src/Model/EventException.php
@@ -516,13 +516,13 @@ class EventException extends DataObject implements PermissionProvider
                     ->setHTML5(true),
                 TimeField::create('ModifiedStartTime', 'Modified Start Time')
                     ->setDescription('Leave empty to use the original start time. Set to 00:00:00 for midnight.')
-                    ->setAttribute('value', $this->ModifiedStartTime ?: ''),
+                    ->setAttribute('value', $this->ModifiedStartTime ?? ''),
                 DateField::create('ModifiedEndDate', 'Modified End Date')
                     ->setDescription('Leave empty to use the original end date')
                     ->setHTML5(true),
                 TimeField::create('ModifiedEndTime', 'Modified End Time')
                     ->setDescription('Leave empty to use the original end time. Set to 00:00:00 for midnight.')
-                    ->setAttribute('value', $this->ModifiedEndTime ?: ''),
+                    ->setAttribute('value', $this->ModifiedEndTime ?? ''),
                 CheckboxField::create('ModifiedAllDay', 'All Day Event')
                     ->setDescription('Override the all-day setting for this instance'),
             ]

--- a/src/Model/EventException.php
+++ b/src/Model/EventException.php
@@ -144,7 +144,7 @@ class EventException extends DataObject implements PermissionProvider
     ];
 
     /**
-     * Check if this exception has an override for a specific property
+     * Check if a specific property has an override value
      *
      * @param string $property
      * @return bool
@@ -158,9 +158,16 @@ class EventException extends DataObject implements PermissionProvider
         }
 
         $overrideField = $overridableFields[$property];
+        $value = $this->$overrideField;
+
+        // For time fields, check if value is explicitly set (not NULL)
+        // This allows users to intentionally set midnight (00:00:00) as an override
+        if (in_array($overrideField, ['ModifiedStartTime', 'ModifiedEndTime'])) {
+            return $value !== null;
+        }
 
         // Check if the override field has a value
-        return !empty($this->$overrideField);
+        return !empty($value);
     }
 
     /**
@@ -508,12 +515,14 @@ class EventException extends DataObject implements PermissionProvider
                     ->setDescription('Leave empty to use the original start date')
                     ->setHTML5(true),
                 TimeField::create('ModifiedStartTime', 'Modified Start Time')
-                    ->setDescription('Leave empty to use the original start time'),
+                    ->setDescription('Leave empty to use the original start time. Set to 00:00:00 for midnight.')
+                    ->setAttribute('value', $this->ModifiedStartTime ?: ''),
                 DateField::create('ModifiedEndDate', 'Modified End Date')
                     ->setDescription('Leave empty to use the original end date')
                     ->setHTML5(true),
                 TimeField::create('ModifiedEndTime', 'Modified End Time')
-                    ->setDescription('Leave empty to use the original end time'),
+                    ->setDescription('Leave empty to use the original end time. Set to 00:00:00 for midnight.')
+                    ->setAttribute('value', $this->ModifiedEndTime ?: ''),
                 CheckboxField::create('ModifiedAllDay', 'All Day Event')
                     ->setDescription('Override the all-day setting for this instance'),
             ]


### PR DESCRIPTION
## Problem

When creating recurring event exceptions with modified titles/content but **without** modifying times, the TimeField component auto-fills with `00:00:00` (midnight) instead of staying `NULL`. This causes `hasOverride()` to return `true` for time fields, creating unintended time overrides and displaying midnight instead of the original event time.

**Original Issue:** Event exceptions not displaying correctly because times were being unintentionally overridden to midnight.

## Root Cause

1. **TimeField auto-fill behavior**: SilverStripe's TimeField component populates with `"00:00:00"` when rendered with a `NULL` database value
2. **hasOverride() logic**: Used `!empty($this->ModifiedStartTime)` which treats `"00:00:00"` as truthy
3. **Result**: Users who never touched time fields ended up with midnight overrides

## Solution

### 1. Updated `hasOverride()` method (lines 146-165)
Changed time field checking from `!empty()` to `!== null`:

```php
// For time fields, check if value is explicitly set (not NULL)
// This allows users to intentionally set midnight (00:00:00) as an override
if (in_array($overrideField, ['ModifiedStartTime', 'ModifiedEndTime'])) {
    return $value !== null;
}
```

This distinguishes between:
- `NULL` = no override, inherit original time
- `"00:00:00"` = explicit midnight override
- Any other time value = explicit override

### 2. Updated `getCMSFields()` TimeField configuration (lines 509-521)
Added `setAttribute('value', ...)` to preserve empty form values:

```php
TimeField::create('ModifiedStartTime', 'Modified Start Time')
    ->setDescription('Leave empty to use the original start time. Set to 00:00:00 for midnight.')
    ->setAttribute('value', $this->ModifiedStartTime ?: ''),
```

This prevents the TimeField from auto-filling `"00:00:00"` when the database value is `NULL`.

### 3. Updated field descriptions
Clarified that users can explicitly set `00:00:00` for midnight when needed.

## Testing Performed

### Scenario 1: Empty fields (NULL)
- **Action**: Leave time fields empty when creating exception
- **Database**: `ModifiedStartTime = NULL`, `ModifiedEndTime = NULL`
- **Result**: ✅ Calendar displays original event time (9:00 PM)

### Scenario 2: Explicit midnight
- **Action**: Set time fields to `00:00:00`
- **Database**: `ModifiedStartTime = "00:00:00"`, `ModifiedEndTime = "00:30:00"`
- **Result**: ✅ Calendar displays midnight (12:00 AM)

### Scenario 3: Clearing previously set times
- **Action**: Select all (Cmd+A) and delete time values, then save
- **Database**: Values return to `NULL`
- **Result**: ✅ Calendar displays original event time again

All scenarios tested with:
- Unit tests: `CarbonRecursionTest::testEventExceptions` ✅
- Browser E2E: Playwright automation testing CMS forms ✅
- Database verification: Direct MySQL queries ✅
- Front-end calendar: Visual confirmation of time display ✅

## User Workflows Enabled

1. **Leave time fields empty** → `NULL` in DB → Inherits original event time
2. **Set explicit midnight** → `"00:00:00"` in DB → Displays midnight
3. **Clear previously set times** → Returns to `NULL` → Inherits original time

## Backward Compatibility

Existing event exceptions with `"00:00:00"` values will continue to work as midnight overrides. No migration needed unless those were unintentional (in which case they can be manually cleared through the CMS).

## Files Changed

- `src/Model/EventException.php`
  - `hasOverride()` method: Lines 146-165
  - `getCMSFields()` TimeField config: Lines 509-521