### PR TITLE
Fix: Display "All Day" in time column for all-day events

### DIFF
--- a/src/Page/EventPage.php
+++ b/src/Page/EventPage.php
@@ -254,6 +254,11 @@ class EventPage extends \Page
      */
     public function getGridFieldTime()
     {
+        // Return "All Day" for all-day events
+        if ($this->AllDay) {
+            return 'All Day';
+        }
+
         /** @var DBTime $date */
         $time = DBField::create_field(DBTime::class, $this->StartTime);
 

--- a/src/Page/EventPage.php
+++ b/src/Page/EventPage.php
@@ -256,7 +256,7 @@ class EventPage extends \Page
     {
         // Return "All Day" for all-day events
         if ($this->AllDay) {
-            return 'All Day';
+            return _t('EventPage.ALL_DAY', 'All Day');
         }
 
         /** @var DBTime $date */


### PR DESCRIPTION
## Summary
Fixes the empty time column display in EventPage GridField when events are set to all day.

## Problem
When an event is configured as "All Day", the time column in the CMS summary fields displays nothing, making it unclear whether the event has a time set or is intentionally all day.

## Solution
Modified `getGridFieldTime()` method to return "All Day" when the `AllDay` property is true, providing clear indication in the GridField that the event is an all-day event.

## Changes
- Updated `EventPage::getGridFieldTime()` to check `AllDay` property
- Returns "All Day" text for all-day events
- Falls back to existing `Nice()` time formatting for timed events

## Testing
- Create or edit an event
- Set "All Day" to "Yes"
- View the event list in Calendar GridField
- Time column should now display "All Day" instead of being empty