### PR TITLE
Add updateLumberjackPagesForGridfield extension hook

### DIFF
--- a/src/Page/Calendar.php
+++ b/src/Page/Calendar.php
@@ -211,6 +211,9 @@ class Calendar extends \Page
 
         $list = $this->addEventPageOptimizations($list);
 
+        // Allow extensions to modify the list before returning
+        $this->extend('updateLumberjackPagesForGridfield', $list, $excluded);
+
         // Let Lumberjack handle pagination through GridField components
         // Don't apply limit() here as it interferes with Lumberjack's pagination
         return $list;


### PR DESCRIPTION
## Summary
Adds an extension hook to `Calendar::getLumberjackPagesForGridfield()` to allow projects to customize EventPage sort order without modifying the module's default behavior.

## Changes
- Added `$this->extend('updateLumberjackPagesForGridfield', $list, $excluded)` hook before returning the DataList
- Maintains default StartDate DESC, StartTime DESC sort order
- Allows extensions to modify the list via `updateLumberjackPagesForGridfield` method

## Use Case
Projects can now create extensions to change the EventPage sort order in the Lumberjack GridField. For example, sorting by `LastEdited DESC` to show recently edited events first instead of sorting by `StartDate`.

## Testing
- Tested in Bethlehem project with CalendarExtension
- Extension successfully modifies sort order from StartDate DESC to LastEdited DESC
- Default behavior unchanged when no extension present